### PR TITLE
Wait for lds/cds push. Add logrus logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,26 +2,70 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cenk/backoff"
 	"github.com/monzo/typhon"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type ServerInfo struct {
 	State string `json:"state"`
 }
 
+type Stats struct {
+	CDSUpdateSuccess int `json:"cluster_manager.cds.update_success"`
+	LDSUpdateSuccess int `json:"listener_manager.lds.update_success"`
+}
+
+var cdsRegex = regexp.MustCompile(`cluster_manager\.cds\.update_success: (\d)`)
+var ldsRegex = regexp.MustCompile(`listener_manager\.lds\.update_success: (\d)`)
+
+func ParseStats(bs []byte) (*Stats, error) {
+	cdsMatch := cdsRegex.FindSubmatch(bs)
+	if len(cdsMatch) != 2 {
+		return nil, errors.New("could not match cds update success")
+	}
+	cds, err := strconv.Atoi(string(cdsMatch[1]))
+	if err != nil {
+		return nil, errors.New("could not parse cds update success as int")
+	}
+
+	ldsMatch := ldsRegex.FindSubmatch(bs)
+	if len(ldsMatch) != 2 {
+		return nil, errors.New("could not match lds update success")
+	}
+	lds, err := strconv.Atoi(string(ldsMatch[1]))
+	if err != nil {
+		return nil, errors.New("could not parse lds update success as int")
+	}
+
+	return &Stats{
+		CDSUpdateSuccess: cds,
+		LDSUpdateSuccess: lds,
+	}, nil
+}
+
 func main() {
+	logger := logrus.New()
+	logger.Formatter = &logrus.TextFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.000Z07:00",
+	}
+	logger.Level = logrus.InfoLevel
+
 	// Should be in format `http://127.0.0.1:9010`
 	host, ok := os.LookupEnv("ENVOY_ADMIN_API")
 	if ok && os.Getenv("START_WITHOUT_ENVOY") != "true" {
-		block(host)
+		logger.Infof("Blocking on an Envoy located at: %v being LIVE and receiving a LDS and CDS update", host)
+		block(logger, host)
 	}
 
 	if len(os.Args) < 2 {
@@ -30,8 +74,9 @@ func main() {
 
 	binary, err := exec.LookPath(os.Args[1])
 	if err != nil {
-		panic(err)
+		logger.WithError(err).Fatal("entrypoint must be provided as an argument")
 	}
+	logger.Infof("Handing over to %v", binary)
 
 	var proc *os.Process
 
@@ -80,31 +125,62 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func block(host string) {
+func block(logger *logrus.Logger, envoyHost string) {
 	if os.Getenv("START_WITHOUT_ENVOY") == "true" {
 		return
 	}
 
-	url := fmt.Sprintf("%s/server_info", host)
+	infoUrl := fmt.Sprintf("%s/server_info", envoyHost)
 
 	b := backoff.NewExponentialBackOff()
-	// We wait forever for envoy to start. In practice k8s will kill the pod if we take too long.
+	// We wait forever for envoy to start and then for a LDS and CDS push. In practice k8s will kill the pod if we take too long.
 	b.MaxElapsedTime = 0
 
 	_ = backoff.Retry(func() error {
-		rsp := typhon.NewRequest(context.Background(), "GET", url, nil).Send().Response()
+		infoRsp := typhon.NewRequest(context.Background(), "GET", infoUrl, nil).Send().Response()
 
 		info := &ServerInfo{}
 
-		err := rsp.Decode(info)
+		err := infoRsp.Decode(info)
 		if err != nil {
+			logger.WithError(err).Infof("Envoy at %v not reachable yet", envoyHost)
 			return err
 		}
 
 		if info.State != "LIVE" {
+			logger.WithError(err).Infof("Envoy at %v not LIVE", envoyHost)
 			return errors.New("not live yet")
 		}
+		logger.Infof("Envoy at %v is LIVE", envoyHost)
+		return nil
+	}, b)
 
+	statsURL := fmt.Sprintf("%s/stats", envoyHost)
+	b = backoff.NewExponentialBackOff()
+
+	// We wait forever for a LDS and CDS push. In practice k8s will kill the pod if we take too long.
+	b.MaxElapsedTime = 0
+	_ = backoff.Retry(func() error {
+		statsRsp := typhon.NewRequest(context.Background(), "GET", statsURL, nil).Send().Response()
+		statsRspBytes, _ := statsRsp.BodyBytes(false)
+
+		stats, err := ParseStats(statsRspBytes)
+		if err != nil {
+			logger.WithError(err).Infof("Could not parse stats response from Envoy at %v: response: %v", envoyHost, statsRspBytes)
+			return err
+		}
+
+		if stats.LDSUpdateSuccess == 0 {
+			logger.Infof("Envoy at %v has not received a LDS update successfully yet", envoyHost)
+			return errors.New("no LDS push yet")
+		}
+
+		if stats.CDSUpdateSuccess == 0 {
+			logger.Infof("Envoy at %v has not received a CDS update successfully yet", envoyHost)
+			return errors.New("no CDS push yet")
+		}
+
+		logger.Infof("Envoy at %v has received a LDS and CDS push", envoyHost)
 		return nil
 	}, b)
 }


### PR DESCRIPTION
# What
In addition to waiting for the Envoy to be `LIVE`, wait for a successful update to the `listeners` and `clusters`.

# Why
This is useful when ran in a service mesh sidecar set-up (such as with Istio) where the main container has no understanding that it might have to wait for networking on startup.

# How
After parsing the `LIVE` status, proceed to poll `/stats` for listener and cluster updates to be non-zero.